### PR TITLE
할일 완료 또는 미완료 개별 리스트 출력 구현 완료, importance(우선순위 및 중요도)에 따른 할 일 리스트 구현 중

### DIFF
--- a/ToDoList/src/main/java/com/clush/todolist/controller/ToDoController.java
+++ b/ToDoList/src/main/java/com/clush/todolist/controller/ToDoController.java
@@ -19,12 +19,13 @@ import com.clush.todolist.service.ToDoService;
 
 
 @RestController
-@RequestMapping("/api/work")
+@RequestMapping("/api")
 public class ToDoController {
 
 	@Autowired
 	private ToDoService todoService;
 	
+	//할일 추가
 	@PostMapping("/work")
 	public ResponseEntity<?> addWork(@RequestBody ToDo todo){
 		todoService.addWork(todo);
@@ -32,6 +33,7 @@ public class ToDoController {
 		return ResponseEntity.ok().body("할 일 추가완료");
 	}
 	
+	//추가한 할일 리스트 출력
 	@GetMapping("/work")
 	public List<ToDo> geteWorkList(){
 		List<ToDo> data = todoService.getWorkList();
@@ -39,12 +41,14 @@ public class ToDoController {
 		return data;
 	}
 	
+	//추가한 할일 수정
 	@PutMapping("/work/{id}")
 	public ResponseEntity<?> editWork(@PathVariable("id") Long id, @RequestBody ToDo todo){
 	    ToDo updatedToDo = todoService.editWork(id, todo);
 	    return ResponseEntity.ok().body(updatedToDo);
 	}
 	
+	//추가한 할일 삭제
 	@DeleteMapping("/work/{id}")
 	public ResponseEntity<?> deleteWork(@PathVariable("id") Long id){
 		
@@ -54,6 +58,18 @@ public class ToDoController {
 		}else {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 ID가 존재하지 않습니다.");
 		}
+	}
+	
+	//완료된 할일 리스트 출력
+	@GetMapping("/work/completed")
+	public List<ToDo> getCompletedWork(){
+		return todoService.getCompleteWork();
+	}
+	
+	//미완료된 할일 리스트 출력
+	@GetMapping("/work/pending")
+	public List<ToDo> getPendingWork(){
+		return todoService.getPendingWork();
 	}
 	
 	

--- a/ToDoList/src/main/java/com/clush/todolist/dto/Importance.java
+++ b/ToDoList/src/main/java/com/clush/todolist/dto/Importance.java
@@ -1,0 +1,5 @@
+package com.clush.todolist.dto;
+
+public enum Importance {
+	high, medium, low;
+}

--- a/ToDoList/src/main/java/com/clush/todolist/dto/ToDoDto.java
+++ b/ToDoList/src/main/java/com/clush/todolist/dto/ToDoDto.java
@@ -17,7 +17,9 @@ public class ToDoDto {
 
 	private String description;
 
-	private boolean completed;
+	private Boolean completed;
+	
+	private Importance importance;
 
 	private LocalDateTime createdAt;
 

--- a/ToDoList/src/main/java/com/clush/todolist/entity/Member.java
+++ b/ToDoList/src/main/java/com/clush/todolist/entity/Member.java
@@ -17,6 +17,7 @@ public class Member extends BaseEntity {
 	
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "userid")
 	private Long userId;
 	
 	@Column(length = 30, nullable = false)

--- a/ToDoList/src/main/java/com/clush/todolist/entity/ToDo.java
+++ b/ToDoList/src/main/java/com/clush/todolist/entity/ToDo.java
@@ -1,12 +1,14 @@
 package com.clush.todolist.entity;
 
+import com.clush.todolist.dto.Importance;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -26,7 +28,11 @@ public class ToDo extends BaseEntity {
 	
 	private String description;
 	
-	private boolean completed;
+	private Boolean completed;
+	
+	@Column(length = 6)
+	@Enumerated(EnumType.STRING)
+	private Importance importance;
 	
 	/*
 	 * @ManyToOne

--- a/ToDoList/src/main/java/com/clush/todolist/repository/ToDoRepository.java
+++ b/ToDoList/src/main/java/com/clush/todolist/repository/ToDoRepository.java
@@ -1,9 +1,15 @@
 package com.clush.todolist.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.clush.todolist.dto.Importance;
 import com.clush.todolist.entity.ToDo;
 
 public interface ToDoRepository extends JpaRepository<ToDo, Long> {
 
+	List<ToDo> findByCompleted(boolean completed);
+
+	List<ToDo> findByImportance(Importance importance);
 }

--- a/ToDoList/src/main/java/com/clush/todolist/service/ToDoService.java
+++ b/ToDoList/src/main/java/com/clush/todolist/service/ToDoService.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.clush.todolist.dto.Importance;
 import com.clush.todolist.entity.ToDo;
 import com.clush.todolist.repository.ToDoRepository;
 
@@ -15,35 +16,59 @@ public class ToDoService {
 
 	@Autowired
 	private ToDoRepository todoRepository;
-	
-	public void addWork (ToDo todo) {
+
+	public void addWork(ToDo todo) {
 		todo.setCompleted(false);
-		
+
 		todoRepository.save(todo);
 	}
-	
-	public List<ToDo> getWorkList(){
-		
+
+	public List<ToDo> getWorkList() {
+
 		List<ToDo> data = new ArrayList<>();
 		data = todoRepository.findAll();
-		
+
 		return data;
 	}
-	
-	public ToDo editWork (Long id, ToDo todo) {
+
+	public ToDo editWork(Long id, ToDo todo) {
 		Optional<ToDo> readyToDo = todoRepository.findById(id);
-		
-		ToDo updateWork = readyToDo.get();
-		updateWork.setTitle(todo.getTitle());
-		updateWork.setDescription(todo.getDescription());
-		updateWork.setCompleted(todo.isCompleted());
-		return todoRepository.save(updateWork);
+		if (readyToDo.isPresent()) {
+			ToDo updateWork = readyToDo.get();
+			if (todo.getTitle() != null) {
+				updateWork.setTitle(todo.getTitle());
+			}
+			if (todo.getDescription() != null) {
+				updateWork.setDescription(todo.getDescription());
+			}
+			if (todo.getCompleted() != null) {
+				updateWork.setCompleted(todo.getCompleted());
+			}
+			if (todo.getImportance() != null) {
+				updateWork.setImportance(todo.getImportance());
+			}
+
+			return todoRepository.save(updateWork);
+		} else {
+			throw new RuntimeException("해당 ID의 작업이 존재하지 않습니다.");
+		}
 	}
-	
+
 	public boolean deleteWork(Long id) {
-		
+
 		todoRepository.deleteById(id);
 		return true;
 	}
-	
+
+	public List<ToDo> getCompleteWork() {
+		return todoRepository.findByCompleted(true);
+	}
+
+	public List<ToDo> getPendingWork() {
+		return todoRepository.findByCompleted(false);
+	}
+
+	public List<ToDo> getWorkByImportance(Importance importance) {
+		return todoRepository.findByImportance(importance);
+	}
 }


### PR DESCRIPTION
entity에 importance추가로 인해서 editwork 수정.
enum으로  importance에 "high, medium, low"만 들어가도록 구현.
service에 importance별로 리스트 출력하는 기능 구현 완료.
controller에 추가 예정.

*
editWork를 부분 데이터만 받아서 업데이트가 가능하도록 구현. -- 클라이언트가 보내는 데이터 양을 줄여서 효율성을 높이려고 함.
ToDo entity의 boolean을 Boolean타입으로 변경하여 null확인 가능하도록 변경.
